### PR TITLE
fix: Spelling in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Anywhy Flake Firmware
 
-> **Important**: If you have a board version prior to 1.0, you should use the cofing from Flake_v0.1/v0.2 [branch](https://github.com/anywhy-io/flake-zmk-module/tree/Flake_v0.1/v0.2) and [actions](https://github.com/anywhy-io/flake-zmk-module/actions?query=branch%3AFlake_v0.1%2Fv0.2).
+> **Important**: If you have a board version prior to 1.0, you should use the config from Flake_v0.1/v0.2 [branch](https://github.com/anywhy-io/flake-zmk-module/tree/Flake_v0.1/v0.2) and [actions](https://github.com/anywhy-io/flake-zmk-module/actions?query=branch%3AFlake_v0.1%2Fv0.2).
 
 <img alt="keymap" width="100%" src="./keymap.svg">


### PR DESCRIPTION
Replaced `cofing` with `config`.