### PR TITLE
fix: update board name for zephyr 4.1 compatibility

### DIFF
--- a/boards/shields/anywhy_flake/anywhy_flake.zmk.yml
+++ b/boards/shields/anywhy_flake/anywhy_flake.zmk.yml
@@ -3,7 +3,7 @@ id: anywhy_flake
 name: Anywhy Flake
 type: shield
 url: https://github.com/anywhy-io/flake
-requires: [seeeduino_xiao_ble]
+requires: [xiao_ble]
 features:
   - keys
   - studio

--- a/build.yaml
+++ b/build.yaml
@@ -18,10 +18,10 @@
 #
 ---
 include:
-  - board: seeeduino_xiao_ble
+  - board: xiao_ble
     shield: anywhy_flake_left
     snippet: studio-rpc-usb-uart
-  - board: seeeduino_xiao_ble
+  - board: xiao_ble
     shield: anywhy_flake_right
-  - board: seeeduino_xiao_ble
+  - board: xiao_ble
     shield: settings_reset


### PR DESCRIPTION
* latest zmk update includes zephyr 4.1 with board renamed from `seeduino_xiao_ble` to `xiao_ble`. `boards/shields/anywhy_flake/anywhy_flake.zmk.yml` and `build.yaml` updated for compatibility.