### PR TITLE
Update board references in build.yaml to xiao_ble//zmk

### DIFF
--- a/boards/shields/anywhy_flake/anywhy_flake.zmk.yml
+++ b/boards/shields/anywhy_flake/anywhy_flake.zmk.yml
@@ -3,7 +3,7 @@ id: anywhy_flake
 name: Anywhy Flake
 type: shield
 url: https://github.com/anywhy-io/flake
-requires: [xiao_ble]
+requires: [xiao_ble//zmk]
 features:
   - keys
   - studio

--- a/build.yaml
+++ b/build.yaml
@@ -18,10 +18,10 @@
 #
 ---
 include:
-  - board: xiao_ble
+  - board: xiao_ble//zmk
     shield: anywhy_flake_left
     snippet: studio-rpc-usb-uart
-  - board: xiao_ble
+  - board: xiao_ble//zmk
     shield: anywhy_flake_right
-  - board: xiao_ble
+  - board: xiao_ble//zmk
     shield: settings_reset


### PR DESCRIPTION
I saw this Firmware is pinned to main branch of ZMK and ZMK just lately renamed the boards: https://zmk.dev/docs/hardware#seeed_xiao

<img width="993" height="307" alt="image" src="https://github.com/user-attachments/assets/3198ceed-6efd-490a-a663-5ebb868926c1" />
